### PR TITLE
removed requirement for <3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "GluPredKit aims to make blood glucose model training and prediction more accessible."
 readme = "README.md"
-requires-python = ">=3.7, <3.10"
+requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Not sure if there are requirements that need python lower than 3.10 for some reason.  But if not we should remove this. 